### PR TITLE
Move state changes to address race condition

### DIFF
--- a/Application/src/main/java/com/example/android/bluetoothchat/BluetoothChatService.java
+++ b/Application/src/main/java/com/example/android/bluetoothchat/BluetoothChatService.java
@@ -154,10 +154,12 @@ public class BluetoothChatService {
             mConnectedThread = null;
         }
 
+        // ensure state is set before starting new thread
+        setState(STATE_CONNECTING);
+
         // Start the thread to connect with the given device
         mConnectThread = new ConnectThread(device, secure);
         mConnectThread.start();
-        setState(STATE_CONNECTING);
     }
 
     /**
@@ -192,6 +194,9 @@ public class BluetoothChatService {
             mInsecureAcceptThread = null;
         }
 
+        // ensure state is set before starting new thread
+        setState(STATE_CONNECTED);
+
         // Start the thread to manage the connection and perform transmissions
         mConnectedThread = new ConnectedThread(socket, socketType);
         mConnectedThread.start();
@@ -202,8 +207,6 @@ public class BluetoothChatService {
         bundle.putString(Constants.DEVICE_NAME, device.getName());
         msg.setData(bundle);
         mHandler.sendMessage(msg);
-
-        setState(STATE_CONNECTED);
     }
 
     /**


### PR DESCRIPTION
Current state must be defined BEFORE starting ConnectedThread. Failure to do so opens a race condition - the "while (mState == STATE_CONNECTED)" loop in run() may exit because mState is not yet current. Particularly nasty, since it doesn't ALWAYS happen.
For consistency, I've moved the state definition in ConnectThread also, making connect() and connected() consistent with start().

I don't believe this issue is addressed by an existing patch (sirmordred), as it is a RACE condition, and his change only alters HOW the state is updated, not WHEN.
