### PR TITLE
Fix a bug, connectionLost() call the start method after stop().

### DIFF
--- a/Application/src/main/java/com/example/android/bluetoothchat/BluetoothChatService.java
+++ b/Application/src/main/java/com/example/android/bluetoothchat/BluetoothChatService.java
@@ -61,6 +61,7 @@ public class BluetoothChatService {
     private ConnectedThread mConnectedThread;
     private int mState;
     private int mNewState;
+    private boolean mStop;
 
     // Constants that indicate the current connection state
     public static final int STATE_NONE = 0;       // we're doing nothing
@@ -79,6 +80,7 @@ public class BluetoothChatService {
         mState = STATE_NONE;
         mNewState = mState;
         mHandler = handler;
+        mStop = false;
     }
 
     /**
@@ -128,6 +130,7 @@ public class BluetoothChatService {
             mInsecureAcceptThread = new AcceptThread(false);
             mInsecureAcceptThread.start();
         }
+        mStop = false;
         // Update UI title
         updateUserInterfaceTitle();
     }
@@ -234,6 +237,7 @@ public class BluetoothChatService {
             mInsecureAcceptThread = null;
         }
         mState = STATE_NONE;
+        mStop = true;
         // Update UI title
         updateUserInterfaceTitle();
     }
@@ -272,7 +276,8 @@ public class BluetoothChatService {
         updateUserInterfaceTitle();
 
         // Start the service over to restart listening mode
-        BluetoothChatService.this.start();
+        if (!mStop)
+            BluetoothChatService.this.start();
     }
 
     /**
@@ -291,7 +296,8 @@ public class BluetoothChatService {
         updateUserInterfaceTitle();
 
         // Start the service over to restart listening mode
-        BluetoothChatService.this.start();
+        if (!mStop)
+            BluetoothChatService.this.start();
     }
 
     /**


### PR DESCRIPTION
I found out a problem. If there have A and B devices are communicating in the BluetoothChatRoom, When the A close this app, the Fragment will call mChatService.stop() in onDestroy method, but the connected thread also call the connectLost() after mChatService.stop(), too. So it will run the start method to run the accept thread again, even through the app is closed. It causes the B devices still can connect to A device and send message, then the A device will get a crash message because it still handling message but there is no UI.
So I think can use a variable to control the BluetoothChatService. If the Fragment call the stop method, the BluetoothChatService can't call itself to start agin in the connectionFailed() and connectionLost().