### PR TITLE
Enable automatic builds with Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 language: android
 android:
   components:
-    - build-tools-27
+    - build-tools-27.0.2
     - android-27
     - add-on
     - extra
+
+licenses:
+    - 'android-sdk-license-.+'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: android
+android:
+  components:
+    - build-tools-27
+    - android-27
+    - add-on
+    - extra

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-Android BluetoothChat Sample
+Android BluetoothChat Sample [![Travis Build Status](https://travis-ci.org/googlesamples/android-BluetoothChat.svg?branch=master)](https://travis-ci.org/googlesamples/android-BluetoothChat)
 ===================================
 
 This sample shows how to implement two-way text chat over Bluetooth between two Android devices, using


### PR DESCRIPTION
Enables continuous integration with Travis. Travis needs to be [enabled](https://github.com/marketplace/travis-ci) in the GitHub Marketplace.

Currently blocked until #40 is merged.
`> Manifest merger failed : uses-sdk:minSdkVersion 11 cannot be smaller than version 14 declared in library [com.android.support:support-v4:27.0.2]`

Previous runs on EwoutH/android-BluetoothChat can be viewed here: https://travis-ci.com/EwoutH/android-BluetoothChat